### PR TITLE
PC-76 Improve the filtering functionality in Active Admin to ensure case insensitivity when using the "equals" filter method.

### DIFF
--- a/config/initializers/active_admin_filters_string_input.rb
+++ b/config/initializers/active_admin_filters_string_input.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module ActiveAdmin
+  module Inputs
+    module Filters
+      class StringInput
+        # Adding new default filters to the string input
+        filter :matches
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
- Added new default filters to the string input field
- Extended the StringInput class from ActiveAdmin