### PR TITLE
PC-156: Update item labels in expanded accordion on the Items & Pricing page

### DIFF
--- a/app/javascript/components/shared/Item.jsx
+++ b/app/javascript/components/shared/Item.jsx
@@ -12,6 +12,7 @@ export const Item = ({ itemData, selectedOptions, setSelectedOptions, quoteId })
     isItemSelectableOptions,
     isShowSimpleParams,
     isShowCombinedParams,
+    isShowIncludedParams,
   } = getItemTypeConditions(quoteItem.item)
 
   const { is_open, is_selectable_options, open_parameters_label, pricing_options, fixed_parameters } = quoteItem.item
@@ -119,18 +120,22 @@ export const Item = ({ itemData, selectedOptions, setSelectedOptions, quoteId })
     </PcItemFormGroup>
   )
 
+  const renderDiscountedPrice = (label = 'Discounted price') => (
+    <PcItemFormGroup paramType="discounted-price" label={label}>
+      <PcItemInputControl
+        paramType="discounted-price"
+        value={Number(quoteItem.final_price) > 0 ? Number(quoteItem.final_price).toFixed(2) : 0}
+      />
+    </PcItemFormGroup>
+  )
+
   return (
     <div>
       {isShowSimpleParams && (
         <div className={'d-flex flex-column gap-3 px-0 align-items-end'}>
           <div className="d-flex flex-wrap align-items-end gap-3">
             {isItemFixed && renderFixedParams()}
-            <PcItemFormGroup paramType="discounted-price" label="Discounted price">
-              <PcItemInputControl
-                paramType="discounted-price"
-                value={Number(quoteItem.final_price) > 0 ? Number(quoteItem.final_price).toFixed(2) : 0}
-              />
-            </PcItemFormGroup>
+            {renderDiscountedPrice()}
           </div>
 
           <div className="d-flex flex-wrap align-items-end gap-3">
@@ -174,16 +179,18 @@ export const Item = ({ itemData, selectedOptions, setSelectedOptions, quoteId })
                   value={Number(quoteItem.price) > 0 ? Number(quoteItem.price).toFixed(2) : 0}
                 />
               </PcItemFormGroup>
-
-              <PcItemFormGroup paramType="discounted-price" label="Discounted price">
-                <PcItemInputControl
-                  paramType="discounted-price"
-                  value={Number(quoteItem.final_price) > 0 ? Number(quoteItem.final_price).toFixed(2) : 0}
-                />
-              </PcItemFormGroup>
+              {renderDiscountedPrice()}
             </div>
 
             <div className="d-flex flex-wrap justify-content-end gap-3">{renderDiscountInput()}</div>
+          </div>
+        </div>
+      )}
+
+      {isShowIncludedParams && (
+        <div className={'d-flex flex-column gap-3 px-0 align-items-end'}>
+          <div className="d-flex flex-wrap align-items-end gap-3">
+            {renderDiscountedPrice('Included price')}
           </div>
         </div>
       )}

--- a/app/javascript/components/shared/MultiSelectDropdown.jsx
+++ b/app/javascript/components/shared/MultiSelectDropdown.jsx
@@ -5,7 +5,7 @@ import { PcCheckboxOption, PcIcon, PcTransparentButton } from '../ui'
 
 export const MultiSelectDropdown = ({
                                       id,
-                                      label = 'Select items',
+                                      label = 'Select Categories & Items',
                                       hasIcon = true,
                                       selectedOptions,
                                       selectableOptions,
@@ -74,8 +74,7 @@ export const MultiSelectDropdown = ({
           <PcCheckboxOption
             label={option.name}
             checked={isSelected(option)}
-            onChange={(e) => {
-            }}
+            onChange={(e) => {}}
             className={'pc-checkbox-items-pricing'}
           />
         )}

--- a/app/javascript/components/utils/getItemTypeConditions.js
+++ b/app/javascript/components/utils/getItemTypeConditions.js
@@ -1,5 +1,12 @@
 export const getItemTypeConditions = (itemData = {}) => {
-  const { is_fixed, is_open, is_selectable_options, fixed_parameters = {}, pricing_options = {} } = itemData
+  const {
+    is_fixed,
+    is_open,
+    is_selectable_options,
+    fixed_parameters = {},
+    pricing_options = {},
+    formula_parameters,
+  } = itemData
 
   const fixedParamCount = Object.keys(fixed_parameters).length
   const openParamCount = itemData.open_parameters_label?.length || 0
@@ -10,7 +17,8 @@ export const getItemTypeConditions = (itemData = {}) => {
   const isItemSelectableOptions = Boolean(!is_fixed && !is_open && is_selectable_options && selectableParamCount === 1)
 
   const isShowSimpleParams = isItemFixed || isItemOpen || isItemSelectableOptions
-  const isShowCombinedParams = !isShowSimpleParams
+  const isShowIncludedParams = Boolean(formula_parameters?.length === 0)
+  const isShowCombinedParams = !isShowSimpleParams && !isShowIncludedParams
 
   return {
     isItemFixed,
@@ -18,5 +26,6 @@ export const getItemTypeConditions = (itemData = {}) => {
     isItemSelectableOptions,
     isShowSimpleParams,
     isShowCombinedParams,
+    isShowIncludedParams,
   }
 }


### PR DESCRIPTION
[![PC-156](https://badgen.net/badge/JIRA/PC-156/009900)](https://cloverpop-internship-2025.atlassian.net/browse/PC-156) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello team, please review the PR

## Description
- Add additional rendering logic for items without pricing parameters
- Update the label name for select Items

<img width="1236" alt="Screenshot 2025-05-22 at 14 45 45" src="https://github.com/user-attachments/assets/e455b30d-4501-40f1-a7a9-8369f9798e0f" />
