### PR TITLE
PC-167: Make the "Include notes with quote" text clickable in the notes section of the item accordion on the Items & Pricing page

### DIFF
--- a/app/assets/stylesheets/application/form_group.scss
+++ b/app/assets/stylesheets/application/form_group.scss
@@ -147,6 +147,8 @@
       font-size: 14px;
       line-height: 1.6;
       color: $gray-light;
+      cursor: pointer;
+      margin-bottom: 0;
     }
 
     .form-check-input {

--- a/app/javascript/components/pages/ItemsPricing.jsx
+++ b/app/javascript/components/pages/ItemsPricing.jsx
@@ -297,7 +297,6 @@ export const ItemsPricing = () => {
                           onBlur={() => handleNotesBlur(item.id)}
                         />
                         <Form.Group
-                          controlId={`include-notes-${item.id}`}
                           className="form-check pc-item-input notes fs-10"
                         >
                           <Form.Check.Input

--- a/app/javascript/components/pages/ItemsPricing.jsx
+++ b/app/javascript/components/pages/ItemsPricing.jsx
@@ -296,13 +296,20 @@ export const ItemsPricing = () => {
                           onChange={(e) => handleNotesChange(item.id, e.target.value)}
                           onBlur={() => handleNotesBlur(item.id)}
                         />
-                        <Form.Check
-                          type={'checkbox'}
-                          label={'Include notes with quote'}
-                          className={'fs-10'}
-                          checked={notesState.include || false}
-                          onChange={(e) => handleIncludeNotesChange(item.id, e.target.checked)}
-                        />
+                        <Form.Group
+                          controlId={`include-notes-${item.id}`}
+                          className="form-check pc-item-input notes fs-10"
+                        >
+                          <Form.Check.Input
+                            type="checkbox"
+                            id={`include-notes-${item.id}`}
+                            checked={notesState.include || false}
+                            onChange={(e) => handleIncludeNotesChange(item.id, e.target.checked)}
+                          />
+                          <Form.Label htmlFor={`include-notes-${item.id}`} className="form-check-label">
+                            Include notes with quote
+                          </Form.Label>
+                        </Form.Group>
                       </PcItemFormGroup>
                     )}
                   </PcItemAccordion>

--- a/app/javascript/components/shared/MultiSelectDropdown.jsx
+++ b/app/javascript/components/shared/MultiSelectDropdown.jsx
@@ -122,7 +122,16 @@ export const MultiSelectDropdown = ({
             </button>
           </div>
         )}
-        inputProps={{ onClick: handleClick }}
+        inputProps={{
+          onClick: handleClick,
+        }}
+        onKeyDown={(e) => {
+          const input = e.target.value
+          if (e.key === 'Backspace' && input === '' && selectedOptions.length > 0) {
+            const updated = selectedOptions.slice(0, -1)
+            onChange(updated)
+          }
+        }}
       />
 
       <Form.Label className="pc-label position-absolute fw-bold fs-10 lh-lg m-0 py-0 px-1" column={true}>


### PR DESCRIPTION
[![PC-167](https://badgen.net/badge/JIRA/PC-167/009900)](https://cloverpop-internship-2025.atlassian.net/browse/PC-167) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello team, please review PR

## Descriptions
- Make the "Include notes with quote" text clickable in the notes section
- Added functionality to delete selected items/categories with the keyboard 'Backspace' button

Thank you