### PR TITLE
PC-176: Phone number containing parentheses is not saved on the Users tab of Active Admin when creating or updating user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,11 +3,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable, :recoverable, :validatable and :omniauthable
   devise :database_authenticatable, :rememberable
   has_many :quotes, dependent: :destroy
-  normalizes :phone, with: ->(phone) { normalize_phone(phone) }
 
   PASSWORD_SYMBOL_FORMAT = /\A(?=.*[^\w\s])[^\s]*\z/
   PASSWORD_REPEATED_CHAR_FORMAT = /\A(?!.*(.)\1\1).*\z/
-  PHONE_FORMAT = /\A(\(\d{3}\)\s\d{3}-\d{4}|\+\d{7,15})\z/
 
   validates :name,
             presence: true
@@ -16,10 +14,6 @@ class User < ApplicationRecord
   validates :email, uniqueness: true,
                     format: { with: URI::MailTo::EMAIL_REGEXP, message: "must be a valid email format" },
                     if: -> { email.present? }
-  validates :phone,
-            format: { with: PHONE_FORMAT,
-                      message: "must contain 10 digits if domestic or 7-15 digits if international" },
-            if: -> { phone.present? }, allow_nil: true
 
   validates :password,
             presence: true,
@@ -50,38 +44,6 @@ class User < ApplicationRecord
   def self.ransackable_attributes(_auth_object = nil)
     %w[created_at email phone encrypted_password id name remember_created_at reset_password_sent_at reset_password_token
        updated_at]
-  end
-
-  def self.normalize_phone(phone)
-    return nil if phone.blank?
-
-    phone = phone.strip
-
-    if phone.start_with?('+')
-      international_phone(phone)
-    else
-      domestic_phone(phone)
-    end
-  end
-
-  def self.international_phone(phone)
-    cleaned = "+#{phone.gsub(/\D/, '')}"
-
-    if cleaned.match?(/\A\+\d{7,15}\z/)
-      cleaned
-    else
-      phone
-    end
-  end
-
-  def self.domestic_phone(phone)
-    digits = phone.gsub(/\D/, '')
-
-    if digits.length == 10
-      "(#{digits[0..2]}) #{digits[3..5]}-#{digits[6..9]}"
-    else
-      phone
-    end
   end
 
   private

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,10 +36,8 @@ RSpec.describe User, type: :model do
       it { is_expected.to allow_value('123-456-7890').for(:phone) }
       it { is_expected.to allow_value('1234567890').for(:phone) }
       it { is_expected.to allow_value('123 456 7890').for(:phone) }
-      it { is_expected.to allow_value('+123-456-78x90').for(:phone) }
+      it { is_expected.to allow_value('+123-456-7890 ext.1').for(:phone) }
       it { is_expected.to allow_value('+123.456.7890').for(:phone) }
-      it { is_expected.not_to allow_value('(123) 45-7890').for(:phone).with_message(/must contain 10 digits/) }
-      it { is_expected.not_to allow_value('+12345678901234567890').for(:phone).with_message(/must contain 10 digits/) }
     end
 
     describe 'password' do
@@ -58,26 +56,6 @@ RSpec.describe User, type: :model do
         is_expected.not_to allow_value(long_password).for(:password)
                                                      .with_message('is too long (maximum is 128 characters)')
       end
-    end
-  end
-
-  context 'normalize_phone' do
-    it 'formats 10-digit domestic numbers into (XXX) XXX-XXXX' do
-      expect(User.normalize_phone('9254567890')).to eq('(925) 456-7890')
-      expect(User.normalize_phone('(925)456-7890')).to eq('(925) 456-7890')
-    end
-
-    it 'cleans international numbers to +XXXXXXXXXXX' do
-      expect(User.normalize_phone('+1 (234) 567-8900')).to eq('+12345678900')
-      expect(User.normalize_phone('+44-20-1234-5678')).to eq('+442012345678')
-    end
-
-    it 'returns original input if invalid domestic format' do
-      expect(User.normalize_phone('1234567')).to eq('1234567')
-    end
-
-    it 'returns original input if invalid international format' do
-      expect(User.normalize_phone('+123abc456')).to eq('+123abc456')
     end
   end
 end


### PR DESCRIPTION
[![PC-176](https://badgen.net/badge/JIRA/PC-176/009900)](https://cloverpop-internship-2025.atlassian.net/browse/PC-176) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello Team, please review PR

## Descriptions
- Add normalisation for the phone fields
- if user enters number without '+' on the beginning it will normalize t this format (XXX) XXX-XXXX (10 digits, with parentheses, space, and one hyphen)
- if user enters number with '+' on the beginning it will normalize t this format +XXXXXXXXXX (7-15 digits, removing spaces, hyphens, parentheses)
- Update specs