### PR TITLE
PC-179: Duplicate parameters are added without validation after clicking "Add Parameter" button on New parameter page in Items tab of Active Admin

### DIFF
--- a/app/admin/items.rb
+++ b/app/admin/items.rb
@@ -288,9 +288,9 @@ ActiveAdmin.register Item do
     @params_data = params
 
     param_name = case @param_type
-                 when "Fixed" then params[:fixed_parameter_name].to_s.strip
-                 when "Open" then params[:open_parameter_name].to_s.strip
-                 when "Select" then params[:select_parameter_name].to_s.strip
+                 when "Fixed" then params[:fixed_parameter_name].to_s.squish
+                 when "Open" then params[:open_parameter_name].to_s.squish
+                 when "Select" then params[:select_parameter_name].to_s.squish
                  end
 
     formula_params = session_service.get(:formula_parameters) || []


### PR DESCRIPTION
[![PC-179](https://badgen.net/badge/JIRA/PC-179/009900)](https://cloverpop-internship-2025.atlassian.net/browse/PC-179) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=wahanegi&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Hello Team, please review the PR

## Description
- Add validation for the uniqueness of pricing parameters in the same quote item